### PR TITLE
Fixes NPE by getting the CSL from the binding object if targetTextCol…

### DIFF
--- a/app/src/main/java/com/example/android/unsplash/DetailActivity.java
+++ b/app/src/main/java/com/example/android/unsplash/DetailActivity.java
@@ -66,7 +66,7 @@ public class DetailActivity extends Activity {
                                        List<View> sharedElementSnapshots) {
             TextView author = binding.author;
             author.setTextSize(TypedValue.COMPLEX_UNIT_PX, targetTextSize);
-            author.setTextColor(targetTextColors);
+            author.setTextColor(targetTextColors != null ? targetTextColors : author.getTextColors());
             forceSharedElementLayout(binding.description);
         }
     };


### PR DESCRIPTION
Hi @keyboardsurfer @nickbutcher @georgemount today I was in the `A window into transitions` session  so I downloaded the sample app and when I was playing around with the app I noticed a crash. 

You just need to rotate the device more than once, if you do that then the `targetTextColors` variable will be null, so If the variable is null then I get it from the `author` `TextView`. 

![giphy](https://cloud.githubusercontent.com/assets/802308/15446217/3571f24c-1ecd-11e6-84b7-7229fad18417.gif)
